### PR TITLE
Fix incorrect version in SYNOPSIS

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ use META6;
 my $m = META6.new(   name        => 'META6',
                      description => 'Work with Perl 6 META files',
                      version     => Version.new('0.0.1'),
-                     perl-version   => Version.new('6'),
+                     perl-version   => Version.new('6.*'),
                      depends     => <JSON::Class>,
                      test-depends   => <Test>,
                      tags        => <devel meta utils>,


### PR DESCRIPTION
the `perl` meta field specifies the minimum acceptable Perl 6 version
the module will work under, but Version.new('6') is after current
6.c and any future language versions as far as we know.

Default to Version.new('6.*'),  6.c is also good, and using version literals
(v6.* or v6.c) is also good

See also: https://irclog.perlgeek.de/perl6/2017-01-26#i_13994899