### PR TITLE
Add license field for META6::Support

### DIFF
--- a/lib/META6.pm
+++ b/lib/META6.pm
@@ -205,6 +205,7 @@ class META6:ver<0.0.13>:auth<github:jonathanstowe> does JSON::Class does AutoAss
         has Str $.mailinglist is rw is specification(Optional) is json-skip-null;
         has Str $.irc is rw         is specification(Optional) is json-skip-null;
         has Str $.phone is rw       is specification(Optional) is json-skip-null;
+        has Str $.license is rw     is specification(Optional) is json-skip-null;
     }
 
     # cope with "v0.0.1"


### PR DESCRIPTION
See https://design.perl6.org/S22.html#license
This field is used in case the license is one of the non-SPDX
standardized names, or possibly in addition to a the license name.