### PR TITLE
 Example of $m<provides> and new test using it. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ print $m.to-json;
 
 my $m = META6.new(file => './META6.json');
 $m<version description> = v0.0.2, 'Work with Perl 6 META files even better';
+say 'Modules in the distribution: ' ~ $m<provides>.keys.join(', ');
 spurt('./META6.json', $m.to-json);
 ```
 ## Description

--- a/t/070-modules_load.t
+++ b/t/070-modules_load.t
@@ -1,0 +1,16 @@
+#! /usr/bin/env perl6
+
+use v6;
+use META6;
+use Test;
+
+my $m = META6.new( file => $*PROGRAM.sibling('../META6.json') );
+my @modules = $m<provides>.keys;
+
+plan @modules.elems; 
+
+for $m<provides>.keys -> $module {
+  use-ok $module, "This module loads: $module";
+}
+
+# vim: expandtab shiftwidth=4 ft=perl6


### PR DESCRIPTION
Adding an example of $m<provides> in README.md to get modules in the distribution. Using this example in test 070-modules_load.t to check if modules defined in META6.json load correctly. 