### PR TITLE
Add adverbs to use the correct JSON::Class

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -31,7 +31,7 @@
     "Test"
   ],
   "depends": [
-    "JSON::Class:ver<0.0.20+>",
+    "JSON::Class:ver<0.0.20+>:auth<zef:jonathanstowe>:api<1.0>",
     "JSON::Name"
   ],
   "meta-version": "1"


### PR DESCRIPTION
It may be failing to be installed because it tries to install `JSON::Class:ver<0.0.6>:auth<zef:vrurg>:api<1.0.5>` so, change it to define the correct author and api.