### PR TITLE
meta-version also needs to be of type Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ my $m = META6.new(   name        => 'META6',
                      },
                      license     => 'Artistic',
                      production  => False,
-                     meta-version   => 1,
+                     meta-version   => Version.new('1'),
 
                  );
 

--- a/lib/META6.rakumod
+++ b/lib/META6.rakumod
@@ -35,7 +35,7 @@ my $m = META6.new(   name        => 'META6',
                      },
                      license     => 'Artistic',
                      production  => False,
-                     meta-version   => 1,
+                     meta-version   => Version.new('1'),
 
                  );
 


### PR DESCRIPTION
In lib/META6.rakumod and README.md, change `meta-version => 1` to `meta-version => Version.new('1')` in the code snippets, since using a plain integer nowadays (META6-v0.0.31) results in an error:

```
Type check failed in assignment to $!meta-version; expected Version but got Int (1)
  in method new at .....
```

The [example program](https://github.com/jonathanstowe/META6/blob/master/examples/my-meta) is not affected, since it (currently) does't use `meta-version`.