### PR TITLE
Change example licenses from "Artistic" to "Artistic-2.0"

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ my $m = META6.new(   name        => 'META6',
                      provides => {
                         META6 => 'lib/META6.pm',
                      },
-                     license     => 'Artistic',
+                     license     => 'Artistic-2.0',
                      production  => False,
                      meta-version   => 1,
 

--- a/examples/my-meta
+++ b/examples/my-meta
@@ -18,7 +18,7 @@ my $m = META6.new(   name           => 'META6',
                      provides       => {
                         META6 => 'lib/META6.pm',
                      },
-                     license        => 'Artistic',
+                     license        => 'Artistic-2.0',
                      production     => False,
 
                  );

--- a/lib/META6.rakumod
+++ b/lib/META6.rakumod
@@ -33,7 +33,7 @@ my $m = META6.new(   name        => 'META6',
                      provides => {
                         META6 => 'lib/META6.pm',
                      },
-                     license     => 'Artistic',
+                     license     => 'Artistic-2.0',
                      production  => False,
                      meta-version   => 1,
 


### PR DESCRIPTION
This makes it a standardized SPDX license identifier (cf. the [list](https://spdx.org/licenses/)), as is necessary for `meta-ok` from `Test::META` to pass correctly (and ensures that it isn't understood as Artistic-1.0).